### PR TITLE
Update transformers Trainer compatibility

### DIFF
--- a/src/tasknet/models.py
+++ b/src/tasknet/models.py
@@ -360,7 +360,7 @@ class Trainer(transformers.Trainer):
     def __init__(self, model, tasks, hparams, tokenizer=None, *args, **kwargs):
         class default:
             output_dir = "./models/multitask_model"
-            evaluation_strategy = "epoch"
+            eval_strategy = "epoch"
             logging_strategy = "epoch"
             overwrite_output_dir = True
             do_train = True


### PR DESCRIPTION
As of transformers v4.41.0, the evaluation_strategy parameter has been deprecated in favor of eval_strategy: https://github.com/huggingface/transformers/releases/tag/v4.41.0.
This change causes compatibility issues in Colab environments using transformers v4.52 or later, see: https://github.com/huggingface/setfit/issues/542.